### PR TITLE
add tips when start without root right

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,4 +1,5 @@
 #include "mainwindow.h"
+#include <QMessageBox>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -50,6 +51,11 @@ MainWindow::~MainWindow()
  */
 void MainWindow::on_start_clicked()
 {
+    if (setuid(0) < 0)
+    {
+       QMessageBox::information(NULL, tr("tips"), tr("Please Start use root rigth"), QMessageBox::Yes);
+       return;
+    }
     if (! snifferStatus) {
         snifferStatus = true;
         view->clearData();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -5,8 +5,9 @@
 #include "sniffer.h"
 #include <unistd.h>
 #include "capturethread.h"
-#include "QtWidgets/QMessageBox"
-#include "QtWidgets/QFileDialog"
+//#include "QtWidgets/QMessageBox"
+//#include "QtWidgets/QFileDialog"
+#include <QFileDialog>
 #include "multiview.h"
 #include "filter.h"
 #include "ui_mainwindow.h"


### PR DESCRIPTION
I find the sniff will crash started without root right. 
the Csniffer::pHandle will not init  success.
